### PR TITLE
add date to release

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -12,7 +12,8 @@
         {
           "sublime_text": ">=3092",
           "version": "0.1.5",
-          "url": "https://github.com/JesseTG/ribosome-sublime/archive/v0.1.5.zip"
+          "url": "https://github.com/JesseTG/ribosome-sublime/archive/v0.1.5.zip",
+          "date": "2018-01-13 09:14:00"
         }
       ]
     }


### PR DESCRIPTION
Hi, I maintain the [default channel](https://github.com/wbond/package_control_channel) for Sublime Text. I'm testing some new validation tooling and it appears your package entry is not correctly formed according to the schema. See also https://docs.sublimetext.io/reference/package-control/repository.html#version-url-date. In addition to the version and URL, a date should be specified. Without that your package is currently missing from the "old" package control site (although our new one [has picked it up](https://packages.sublimetext.io/packages/Ribosome%20Syntax/)). 